### PR TITLE
[0.3.0-stable-r1] Support log rotation

### DIFF
--- a/base/scheduler.py
+++ b/base/scheduler.py
@@ -96,7 +96,7 @@ def post_scheduler(pending_objects, updating_objects, **kwargs):
         # abort if client instantiation failed
         if not client:
             verbose_error = 'Client "%s" has failed to be instantiated' % account_id
-            log_error = message("LOG_EXCEPT", exception=e, verbose=verbose_error, object=account.pk)
+            log_error = message("LOG_EXCEPT", exception=None, verbose=verbose_error, object=account.pk)
             logger.error(log_error)
             continue
         clients[account.pk] = dict(account_id=account_id, client=client, host=host)

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/irfanhakim-as/dim:0.3.0-preview-r1
+FROM ghcr.io/irfanhakim-as/dim:0.3.0-stable-r1
 
 # ================= DO NOT EDIT BEYOND THIS LINE =================
 

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/irfanhakim-as/dim:0.2.1-stable-r1
+FROM ghcr.io/irfanhakim-as/dim:0.3.0-preview-r1
 
 # ================= DO NOT EDIT BEYOND THIS LINE =================
 

--- a/container/alpine.Dockerfile
+++ b/container/alpine.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/irfanhakim-as/dim-alpine:0.2.1-preview-r4
+FROM ghcr.io/irfanhakim-as/dim-alpine:0.3.0-preview-r1
 
 # ================= DO NOT EDIT BEYOND THIS LINE =================
 

--- a/container/alpine.Dockerfile
+++ b/container/alpine.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/irfanhakim-as/dim-alpine:0.3.0-preview-r1
+FROM ghcr.io/irfanhakim-as/dim-alpine:0.3.0-stable-r1
 
 # ================= DO NOT EDIT BEYOND THIS LINE =================
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,5 @@
 #!/usr/bin/env sh
 
-export APP_ROOT="${APP_ROOT:-'base'}"
-export APACHE_USER="${APACHE_USER:-'www-data'}"
-export LOG_PATH="${LOG_PATH:-'/var/log/django'}"
-
 # ================= DO NOT EDIT BEYOND THIS LINE =================
 
 python3 manage.py makemigrations

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 
-export APP_ROOT="${APP_ROOT:-base}"
-export APACHE_USER="${APACHE_USER:-www-data}"
+export APP_ROOT="${APP_ROOT:-'base'}"
+export APACHE_USER="${APACHE_USER:-'www-data'}"
 export LOG_PATH="${LOG_PATH:-'/var/log/django'}"
 
 # ================= DO NOT EDIT BEYOND THIS LINE =================

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,7 @@
 
 export APP_ROOT="${APP_ROOT:-base}"
 export APACHE_USER="${APACHE_USER:-www-data}"
+export LOG_PATH="${LOG_PATH:-'/var/log/django'}"
 
 # ================= DO NOT EDIT BEYOND THIS LINE =================
 
@@ -9,9 +10,9 @@ python3 manage.py makemigrations
 
 python3 manage.py migrate
 
-chmod -R 775 "/${APP_ROOT}" /var/log/apache2
+chmod -R 775 "/${APP_ROOT}" "${LOG_PATH}"
 
-chown -R "${APACHE_USER}": "/${APP_ROOT}" /var/log/apache2
+chown -R "${APACHE_USER}": "/${APP_ROOT}" "${LOG_PATH}"
 
 python3 manage.py test
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,10 +5,6 @@ export APACHE_USER="${APACHE_USER:-www-data}"
 
 # ================= DO NOT EDIT BEYOND THIS LINE =================
 
-if [ -f "/etc/init.d/celeryd" ] && [ -f "/etc/init.d/celerybeat" ]; then
-    BACKEND_SCHEDULER="celery"
-fi
-
 python3 manage.py makemigrations
 
 python3 manage.py migrate
@@ -22,7 +18,7 @@ python3 manage.py test
 if [ ${?} -eq 0 ]; then
     python3 manage.py entrypoint > /dev/null 2>&1
 
-    if [ "${BACKEND_SCHEDULER}" = "celery" ]; then
+    if [ -f "/etc/init.d/celeryd" ] && [ -f "/etc/init.d/celerybeat" ]; then
         /etc/init.d/celeryd start && /etc/init.d/celerybeat start
     fi
 


### PR DESCRIPTION
# Changes

- Upgraded base image version to `0.3.0-stable-r1`
- No longer updated the ownership/perms for the webserver (apache) log path, only do so for the (configurable) django log path - may need to observe for long-term implications
- Removed some redundant declaration of env vars in entrypoint script - which were already set in Dockerfile/base image
- Bug fix: Removed the inclusion of an unassigned var in an error log message

# Related issues/PRs

- https://github.com/irfanhakim-as/dim/pull/6